### PR TITLE
Optimized zeroPoint determination

### DIFF
--- a/components/zmpt101b/zmpt101b.cpp
+++ b/components/zmpt101b/zmpt101b.cpp
@@ -41,7 +41,8 @@ float ZMPT101B::getRmsVoltage(uint8_t loopCount)
 
 	for (uint8_t i = 0; i < loopCount; i++)
 	{
-		int zeroPoint = this->getZeroPoint();
+		int zeroPoint = this->zeroPoint;
+		if (zeroPoint == 0) zeroPoint = this->getZeroPoint();
 
 		int32_t Vnow = 0;
 		uint32_t Vsum = 0;
@@ -58,7 +59,7 @@ float ZMPT101B::getRmsVoltage(uint8_t loopCount)
 			Vsum += (Vnow * Vnow);
 			measurements_count++;
 		}
-		zeroPoint = Zsum / measurements_count; // new value
+		this->zeroPoint = Zsum / measurements_count; // store new value
 		
 		readingVoltage += sqrt(Vsum / measurements_count) / ADC_SCALE * VREF * this->sensitivity;
 	}

--- a/components/zmpt101b/zmpt101b.cpp
+++ b/components/zmpt101b/zmpt101b.cpp
@@ -47,14 +47,19 @@ float ZMPT101B::getRmsVoltage(uint8_t loopCount)
 		uint32_t Vsum = 0;
 		uint32_t measurements_count = 0;
 		uint32_t t_start = micros();
+		uint32_t Zsum = 0;
 
 		while (micros() - t_start < this->period)
 		{
-			Vnow = analogRead(pin) - zeroPoint;
+			uint32_t analogValue = analogRead(pin);
+			Zsum += analogValue; // used to re-calculate zeroPoint (every cycle) to (better) handle shifting vcc values
+			
+			Vnow = analogValue - zeroPoint;
 			Vsum += (Vnow * Vnow);
 			measurements_count++;
 		}
-
+		zeroPoint = Zsum / measurements_count; // new value
+		
 		readingVoltage += sqrt(Vsum / measurements_count) / ADC_SCALE * VREF * this->sensitivity;
 	}
 

--- a/components/zmpt101b/zmpt101b.h
+++ b/components/zmpt101b/zmpt101b.h
@@ -32,6 +32,7 @@ private:
 	uint32_t period;
 	float 	 sensitivity;
 	int 	 getZeroPoint();
+	int		zeroPoint = 0;
 };
 
 }


### PR DESCRIPTION
Hi,

I altered the code so zeroPoint determination does not use an extra cycle when measuring.

The read analog values are used to determine the zeroPoint while measuring the voltage and the determined value can immediately used in the next measurement cycle.

Kind regard,

Ralph.